### PR TITLE
Correctly switching to the grader directory in executeGrader.sh

### DIFF
--- a/custom-graders/FactoringGrader/GraderFiles/executeGrader.sh
+++ b/custom-graders/FactoringGrader/GraderFiles/executeGrader.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Switch to the grader directory
-cd grader
+cd /grader
 
 # Compile the learner's program in the current directory.
 javac -d . /shared/submission/Factoring.java

--- a/custom-graders/FactoringGrader/GraderFiles/executeGrader.sh
+++ b/custom-graders/FactoringGrader/GraderFiles/executeGrader.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# Switch to the grader directory
+cd grader
+
 # Compile the learner's program in the current directory.
 javac -d . /shared/submission/Factoring.java
 

--- a/custom-graders/PrimeGrader/GraderFiles/executeGrader.sh
+++ b/custom-graders/PrimeGrader/GraderFiles/executeGrader.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Switch to the grader directory
-cd grader
+cd /grader
 
 # Compile the learner's program in the current directory.
 javac -d . /shared/submission/Prime.java

--- a/custom-graders/PrimeGrader/GraderFiles/executeGrader.sh
+++ b/custom-graders/PrimeGrader/GraderFiles/executeGrader.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# Switch to the grader directory
+cd grader
+
 # Compile the learner's program in the current directory.
 javac -d . /shared/submission/Prime.java
 


### PR DESCRIPTION
Some recent edits deleted the line "WORKDIR grader" in the Dockerfile causing the executeGrader.sh to fall out of sync with the Dockerfile. This cause the executeGrader.sh to compile java files and place the output in the root directory. Adding 'cd grader' in executeGrader.sh to resolve this issue.
