### PR TITLE
Using ubuntu:latest gives errors during docker build

### DIFF
--- a/custom-graders/DemoAssignmentGrader/GraderFiles/Dockerfile
+++ b/custom-graders/DemoAssignmentGrader/GraderFiles/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch latest ubuntu docker image
+# Fetch ubuntu 14.04 LTS docker image
 FROM ubuntu:14.04
 
 # Install Java on your ubuntu image.

--- a/custom-graders/DemoAssignmentGrader/GraderFiles/Dockerfile
+++ b/custom-graders/DemoAssignmentGrader/GraderFiles/Dockerfile
@@ -1,5 +1,5 @@
 # Fetch latest ubuntu docker image
-FROM ubuntu:latest
+FROM ubuntu:14.04
 
 # Install Java on your ubuntu image.
 RUN \


### PR DESCRIPTION
ubuntu:14.04 works fine for me.
specifying specific version number here is probably ideal.
